### PR TITLE
Mocap distinction between ground truth & perfect pose estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ It the publishes on:
 ### go2_mocap.launch.py
 Connects to a Qualisys Mocap System and converts the data recevied in the expected output format of an odometry node of our Go2 stack. This allows to have a "perfect" odometry node that contains the ground truth data.
 
-Launches the following:
+Two versions of this node can be launched depending on the value of the parameter `mocap_ground_truth`:
+#### `mocap_ground_truth = 0` : [default value] node acts as a perfect pose estimator :
+Are launched the following;
+**go2_state_publisher.launch.py** (detailled further down).
 
 ##### go2_odometry/mocap_base_pose.py 
 Node charged of the communication with the Motion Capture system.
@@ -81,7 +84,19 @@ Published topics:
 Takes several ros parameters :
 - base_frame (default: 'base') : name of the robot base frame
 - odom_frame (default: 'odom') : name of the fixed frame 
-- wanted_body (default: 'go2') : name of the object to be tracked in the motion capture software
+- wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
+- qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
+- publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
+
+#### `mocap_ground_truth = 1` : node acts as a ground truth publisher :
+
+Published topics:
+* `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
+
+Takes several ros parameters :
+- base_frame (default: '**base_mocap**') : name of the robot base frame
+- odom_frame (default: 'odom') : name of the fixed frame 
+- wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
 - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
 - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
 

--- a/README.md
+++ b/README.md
@@ -70,35 +70,37 @@ It the publishes on:
 Connects to a Qualisys Mocap System and converts the data recevied in the expected output format of an odometry node of our Go2 stack. This allows to have a "perfect" odometry node that contains the ground truth data.
 
 Two versions of this node can be launched depending on the value of the parameter `mocap_ground_truth`:
-#### `mocap_ground_truth = 0` : [default value] node acts as a perfect pose estimator :
-Are launched the following;
-**go2_state_publisher.launch.py** (detailled further down).
+1. **`mocap_ground_truth = 0` : [default value] node acts as a perfect pose estimator :**
+    
+    Are launched the following:  
+    **go2_state_publisher.launch.py** (detailled further down).
+   
+    ##### go2_odometry/mocap_base_pose.py 
+    Node charged of the communication with the Motion Capture system.
+    
+    Published topics:
+    * `/odometry/filtered`: position of the robot base
+    * `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
+    
+    Takes several ros parameters :
+    - base_frame (default: 'base') : name of the robot base frame
+    - odom_frame (default: 'odom') : name of the fixed frame 
+    - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
+    - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
+    - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
 
-##### go2_odometry/mocap_base_pose.py 
-Node charged of the communication with the Motion Capture system.
+2. **`mocap_ground_truth = 1` : node acts as a ground truth publisher :**
 
-Published topics:
-* `/odometry/filtered`: position of the robot base
-* `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
-
-Takes several ros parameters :
-- base_frame (default: 'base') : name of the robot base frame
-- odom_frame (default: 'odom') : name of the fixed frame 
-- wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
-- qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
-- publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
-
-#### `mocap_ground_truth = 1` : node acts as a ground truth publisher :
-
-Published topics:
-* `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
-
-Takes several ros parameters :
-- base_frame (default: '**base_mocap**') : name of the robot base frame
-- odom_frame (default: 'odom') : name of the fixed frame 
-- wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
-- qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
-- publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
+    Published topics:  
+    * `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
+    
+    Takes several ros parameters :
+    - base_frame (default: '**base_mocap**') : name of the robot base frame
+    - odom_frame (default: 'odom') : name of the fixed frame 
+    - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
+    - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
+    - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
+      
 >[!NOTE]
 >If you'd like to use the motion capture as a ground truth run:
 >```bash

--- a/README.md
+++ b/README.md
@@ -87,52 +87,17 @@ Ros parameters :
 - `publishing_freq` (default: 110) : publishing frequency of the transform & odometry topics
 - `mimic_go2_odometry` (default: 1) : defines the dehavior of the mocap node
 
-
-**If the parameter `mimic_go2_odometry` is passed to 0 when running the launch file the behavior of the node is altered so that it can be used as a ground truth publisher :**
-What changes is:
-- **go2_state_publisher.launch.py** is not launched
-- **go2_odometry/mocap_base_pose.py** is launched but :
-    1. The topic `/odometry/filtered` is not published anymore
-    2. The tf now publishes a transform between `odom` and **`base_mocap`** (originally between `odom` and `base`)
-<!-- 
-Two versions of this node can be launched depending on the value of the parameter `mocap_ground_truth`:
-1. **`mocap_ground_truth = 0` : [default value] node acts as a perfect pose estimator :**
-    
-    Are launched the following:  
-    **go2_state_publisher.launch.py** (detailled further down).
-   
-    ##### go2_odometry/mocap_base_pose.py 
-    Node charged of the communication with the Motion Capture system.
-    
-    Published topics:
-    * `/odometry/filtered`: position of the robot base
-    * `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
-    
-    Takes several ros parameters :
-    - base_frame (default: 'base') : name of the robot base frame
-    - odom_frame (default: 'odom') : name of the fixed frame 
-    - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
-    - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
-    - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
-
-2. **`mocap_ground_truth = 1` : node acts as a ground truth publisher :**
-
-    Published topics:  
-    * `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
-    
-    Takes several ros parameters :
-    - base_frame (default: '**base_mocap**') : name of the robot base frame
-    - odom_frame (default: 'odom') : name of the fixed frame 
-    - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
-    - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
-    - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
-       -->
 >[!NOTE]
 >If you'd like to use the motion capture as a ground truth run:
 >```bash
 >ros2 launch go2_odometry go2_mocap.launch.py mimic_go2_odometry:=0
 >```
-> The mocap pose will be published as a transform between `odom` and `base_mocap`
+>The parameter `mimic_go2_odometry` changes the behavior of the node so that it can be used as a ground truth publisher.  
+>What changes is:
+>- **go2_state_publisher.launch.py** is not launched
+>- **go2_odometry/mocap_base_pose.py** is launched but :
+>    1. The topic `/odometry/filtered` is not published anymore
+>    2. The tf now publishes a transform between `odom` and **`base_mocap`** (originally between `odom` and `base`)
 
 ---
 ### go2_fake_odometry.launch.py

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Takes several ros parameters :
 - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
 - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
 - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
+>[!NOTE]
+>If you'd like to use the motion capture as a ground truth run:
+>```bash
+>ros2 launch go2_odometry go2_mocap.launch.py mocap_ground_truth:=1
+>```
+> The mocap pose will be published as a transform between `odom` and `base_mocap`
 
 ---
 ### go2_fake_odometry.launch.py

--- a/README.md
+++ b/README.md
@@ -67,8 +67,34 @@ It the publishes on:
 
 ---
 ### go2_mocap.launch.py
-Connects to a Qualisys Mocap System and converts the data recevied in the expected output format of an odometry node of our Go2 stack. This allows to have a "perfect" odometry node that contains the ground truth data.
+Connects to a Qualisys Motion Capture and converts the data recevied in the expected output format of an odometry node of our Go2 stack. This allows to have a "perfect" odometry node that contains the ground truth data.
 
+By default the node launches:
+**go2_state_publisher.launch.py** (detailled further down).
+
+##### go2_odometry/mocap_base_pose.py 
+Node charged of the communication with the Qualisys Motion Capture system.
+
+Published topics:
+* `/odometry/filtered`: position of the robot base
+* `/tf` : Transform between *odom_frame* (fixed) and *base_frame* (tied to the robot)
+
+Ros parameters :
+- `base_frame` (default: 'base') : name of the robot base frame
+- `odom_frame` (default: 'odom') : name of the fixed frame 
+- `wanted_body` (default: 'Go2') : name of the object to be tracked in the motion capture software
+- `qualisys_ip` (default: 192.168.75.2) : IP used to communicate with the motion capture software
+- `publishing_freq` (default: 110) : publishing frequency of the transform & odometry topics
+- `mimic_go2_odometry` (default: 1) : defines the dehavior of the mocap node
+
+
+**If the parameter `mimic_go2_odometry` is passed to 0 when running the launch file the behavior of the node is altered so that it can be used as a ground truth publisher :**
+What changes is:
+- **go2_state_publisher.launch.py** is not launched
+- **go2_odometry/mocap_base_pose.py** is launched but :
+    1. The topic `/odometry/filtered` is not published anymore
+    2. The tf now publishes a transform between `odom` and **`base_mocap`** (originally between `odom` and `base`)
+<!-- 
 Two versions of this node can be launched depending on the value of the parameter `mocap_ground_truth`:
 1. **`mocap_ground_truth = 0` : [default value] node acts as a perfect pose estimator :**
     
@@ -100,11 +126,11 @@ Two versions of this node can be launched depending on the value of the paramete
     - wanted_body (default: 'Go2') : name of the object to be tracked in the motion capture software
     - qualisys_ip (default: 192.168.75.2) : IP used to communicate with the motion capture software
     - publishing_freq (default: 110) : publishing frequency of the transform & odometry topics
-      
+       -->
 >[!NOTE]
 >If you'd like to use the motion capture as a ground truth run:
 >```bash
->ros2 launch go2_odometry go2_mocap.launch.py mocap_ground_truth:=1
+>ros2 launch go2_odometry go2_mocap.launch.py mimic_go2_odometry:=0
 >```
 > The mocap pose will be published as a transform between `odom` and `base_mocap`
 

--- a/launch/go2_mocap.launch.py
+++ b/launch/go2_mocap.launch.py
@@ -2,9 +2,9 @@ from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution, LaunchConfiguration, TextSubstitution, PythonExpression
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration, TextSubstitution
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import IfCondition
+from launch.conditions import  UnlessCondition
 
 def generate_launch_description():
 
@@ -14,10 +14,10 @@ def generate_launch_description():
                                     'go2_state_publisher.launch.py'
                                   ])
     
-    mocap_use_arg = DeclareLaunchArgument(
-                    'mocap_ground_truth',
-                    default_value=TextSubstitution(text='0'),
-                    description='Types of use of the motion capture: 1 (as a ground truth), 0 (as a perfect pose estimator) \n\t\tIf 1 is selected will publish on /tf odom -> base_mocap \n\t\tIf 0 is selected will publish on /tf odom -> base as well as /odometry/filtered'
+    mimic_go2_odometry_arg = DeclareLaunchArgument(
+                    'mimic_go2_odometry',
+                    default_value=TextSubstitution(text='1'),
+                    description='Types of use of the motion capture: 0 (as a ground truth), 1 (as a perfect pose estimator) \n\t\tIf 0 is selected will publish on /tf odom -> base_mocap \n\t\tIf 1 is selected will publish on /tf odom -> base as well as /odometry/filtered'
     )
 
     mocap_base_frame_arg = DeclareLaunchArgument(
@@ -52,7 +52,7 @@ def generate_launch_description():
         mocap_object_name_arg,
         mocap_ip_arg,
         mocap_publishing_freq_arg,
-        mocap_use_arg,
+        mimic_go2_odometry_arg,
 
         Node(
             package="go2_odometry",
@@ -64,7 +64,7 @@ def generate_launch_description():
             "wanted_body": LaunchConfiguration('wanted_body'),
             "qualisys_ip": LaunchConfiguration('qualisys_ip'),
             "publishing_freq": LaunchConfiguration('publishing_freq'),
-            "mocap_ground_truth": LaunchConfiguration('mocap_ground_truth')
+            "mimic_go2_odometry": LaunchConfiguration('mimic_go2_odometry')
         }]
         )
         ,
@@ -72,7 +72,7 @@ def generate_launch_description():
         IncludeLaunchDescription
         (
             PythonLaunchDescriptionSource([minimal_state_publisher_launch_file]),
-            condition=IfCondition(PythonExpression(["'",LaunchConfiguration('mocap_ground_truth'),"' == '0'"]))
+            condition=UnlessCondition(LaunchConfiguration('mimic_go2_odometry'))
         )
 
 

--- a/launch/go2_mocap.launch.py
+++ b/launch/go2_mocap.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description():
 
     mocap_base_frame_arg = DeclareLaunchArgument(
                             'base_frame',
-                            default_value='base_mocap',
+                            default_value='base',
                             description='[IF MOCAP] Name of the base frame (fixed to robot) of the mocap.'
     )
     mocap_odom_frame_arg = DeclareLaunchArgument(

--- a/launch/go2_mocap.launch.py
+++ b/launch/go2_mocap.launch.py
@@ -4,7 +4,7 @@ from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import PathJoinSubstitution, LaunchConfiguration, TextSubstitution
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import  UnlessCondition
+from launch.conditions import  IfCondition
 
 def generate_launch_description():
 
@@ -72,7 +72,7 @@ def generate_launch_description():
         IncludeLaunchDescription
         (
             PythonLaunchDescriptionSource([minimal_state_publisher_launch_file]),
-            condition=UnlessCondition(LaunchConfiguration('mimic_go2_odometry'))
+            condition=IfCondition(LaunchConfiguration('mimic_go2_odometry'))
         )
 
 

--- a/scripts/mocap_base_pose.py
+++ b/scripts/mocap_base_pose.py
@@ -21,14 +21,14 @@ class MocapOdometryNode(Node):
     def __init__(self):
         super().__init__('mocap_base_estimator') 
 
+        # ros2 parameters ======================================================
         self.declare_parameter("odom_frame", "odom")
         self.declare_parameter("wanted_body","Go2") # go2, cube or None
         self.declare_parameter("qualisys_ip","192.168.75.2")
         self.declare_parameter("publishing_freq",110)     # in Hz : due to the discretisation the frequency may be slightly lower than what is it set to. Max limit of 300Hz (set in MoCap software)
         self.declare_parameter("mimic_go2_odometry",0)
         self.mocap_as_pose_estimate = bool(self.get_parameter("mimic_go2_odometry").value)
-
-        # change name od base_frame according to use choosen
+        # change name of base_frame according to use case
         if  self.mocap_as_pose_estimate :
             self.declare_parameter("base_frame","base")
         else:
@@ -40,13 +40,14 @@ class MocapOdometryNode(Node):
             
             self.destroy_node()
             return
-
-
+        
+        # publishers ===========================================================
         self.tf_broadcaster = TransformBroadcaster(self)
 
         if self.mocap_as_pose_estimate : # publish odometry if mocap is used as a perfect pose estimator
             self.odometry_publisher = self.create_publisher(Odometry, 'odometry/filtered', 10)
 
+        # startup info =========================================================
         self.get_logger().info("MoCap started with parameters:")
         self.get_logger().info("base_frame: "+self.get_parameter("base_frame").value)
         self.get_logger().info("odom_frame: "+self.get_parameter("odom_frame").value)
@@ -56,7 +57,7 @@ class MocapOdometryNode(Node):
         self.get_logger().info("mimic_go2_odometry: " + str(self.mocap_as_pose_estimate ))
 
 
-        # Connecting to the motion capture
+        # Connecting to the motion capture =====================================
         asyncio.ensure_future(self.setup())
         self.loop = asyncio.get_event_loop()
         self.loop.run_forever()

--- a/scripts/mocap_base_pose.py
+++ b/scripts/mocap_base_pose.py
@@ -19,7 +19,7 @@ from nav_msgs.msg import Odometry
 
 class MocapOdometryNode(Node):
     def __init__(self):
-        super().__init__('feet_to_odom') 
+        super().__init__('mocap_base_estimator') 
 
         self.declare_parameter("base_frame", "base")
         self.declare_parameter("odom_frame", "odom")


### PR DESCRIPTION
Adds distinction between use of mocap for ground truth and use as a perfect pose estimator :
- new parameter `mocap_ground_truth` for go2_mocap.launch.py & mocap_base_pose.py 
  - `mocap_ground_truth`=1 => mocap used as ground truth : will only publish tf between odom & base_mocap
  - `mocap_ground_truth`=0  => mocap used as perfect pose estimator : "old behavior":  will publish tf between odom & base,  `/odometry/filtered` +  launches state publisher
-  README update matching the changes