### PR TITLE
Topic/initialize filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,23 @@ The main dependencies of this package are:
 ## Launchfiles
 
 ### go2_odometry_switch.launch.py
-"Main" launch file that takes a `mocap_type` argument to select between odometry sources.
-The choices are : `use_full_odom` (default), `fake`, `mocap`
+"Main" launch file that takes a `odom_type` argument to select between odometry sources.
+The choices are : `use_full_odom` (default), `fake`, `mocap`.
+
+`use_full_odom` (a.k.a the *Inekf filter*) is the **preferred** odom type, the others are mostly here for test and debug purposes.
 
 Command:
 ```bash
 ros2 launch go2_odometry go2_odometry_switch.launch.py odom_type:=<your choice>
 ```
 
-- `mocap_type:=use_full_odom`
+- `odom_type:=use_full_odom`
 Calls the **go2_inekf_odometry.launch.py** launch file.
 
-- `mocap_type:=fake`
+- `odom_type:=fake`
 Calls the **go2_fake_odom.launch.py** file.
 
-- `mocap_type:=mocap`
+- `odom_type:=mocap`
 Calls the **go2_mocap.launch.py** file.
 
 Parameters available depending on the odometry used :

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -90,11 +90,11 @@ class Inekf(Node):
         contact_list, pose_list, normed_covariance_list = self.feet_transformations(msg)
 
         if self.pause:
-            if any(contact_list):
+            if all(contact_list):
                 self.pause = False
-                self.get_logger().info("One foot (or more) in contact with the ground: starting filter.")
+                self.get_logger().info("All feet in contact with the ground: starting filter.")
             else:
-                self.get_logger().info("Waiting for one or more foot to touch the ground to start filter.", once=True)
+                self.get_logger().info("Waiting for all feet to touch the ground to start filter.", once=True)
                 return  # Skip the rest of the filter
 
         # Propagation step: using IMU

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, QoSHistoryPolicy
 
 from nav_msgs.msg import Odometry
 from unitree_go.msg import LowState
@@ -52,9 +53,12 @@ class Inekf(Node):
         self.foot_frame_name = [prefix + "_foot" for prefix in ["FL", "FR", "RL", "RR"]]
         self.foot_frame_id = [self.robot.model.getFrameId(frame_name) for frame_name in self.foot_frame_name]
         self.imu_frame_id = self.robot.model.getFrameId("imu")
+        self.base_frame_id = self.robot.model.getFrameId(self.base_frame)
 
         # In/Out topics
-        self.lowstate_subscription = self.create_subscription(LowState, "/lowstate", self.listener_callback, 10)
+        self.lowstate_subscription = self.create_subscription(
+            LowState, "/lowstate", self.listener_callback, QoSProfile(history=QoSHistoryPolicy.KEEP_LAST, depth=10)
+        )
         self.odom_publisher = self.create_publisher(Odometry, "/odometry/filtered", 1)
         self.tf_broadcaster = TransformBroadcaster(self)
 

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -192,7 +192,7 @@ class Inekf(Node):
         pose_list = []
         normed_covariance_list = []
         for i in range(4):
-            pose_list.append(self.robot.data.oMf[self.foot_frame_id[i]])
+            pose_list.append(self.robot.data.oMf[self.foot_frame_id[i]].copy())
 
             Jc = pin.getFrameJacobian(self.robot.model, self.robot.data, self.foot_frame_id[i], pin.LOCAL)[:3, 6:]
             normed_cov_pose = Jc @ Jc.transpose()

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -179,7 +179,7 @@ class Inekf(Node):
             footMimu = oMfoot.actInv(oMimu)
             z_avg += footMimu.translation[2]
         z_avg /= 4.0
-        imu_position = np.array([0.0, 0.0, z_avg])
+        imu_position = np.array([0.0, 0.0, z_avg + 0.025])  # Add foot thickness of 2.5 cm
 
         # Filter state
         state = self.filter.getState()

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -162,7 +162,7 @@ class Inekf(Node):
 
         q[3:7] /= np.linalg.norm(q[3:7])  # Normalize quaternion
 
-        # Computer FK
+        # Compute FK
         pin.forwardKinematics(self.robot.model, self.robot.data, q, v)
         pin.updateFramePlacements(self.robot.model, self.robot.data)
 


### PR DESCRIPTION
Hello,
Following https://github.com/inria-paris-robotics-lab/go2_odometry/issues/25.

* I used the lowstate quaternion estimated by the IMU to initialize the rotation (but forcing the yaw to zero so that the robot always face the x axis at start)
* I use the FK to intialize the filter z position, assuming the average height of all the feet should be equal to 0. (taking a 2.5cm foot thickness into account - computed by hand from the urdf)

I also did a "bug" fix (or it was not a bug at that time but was now and would have been in the future) : 
* Here we are putting a ref to the frame pose in the list. So any modification of self.robot.data will change the feet pose. I added a `.copy()` to prevent that
  https://github.com/inria-paris-robotics-lab/go2_odometry/blob/c8f6f4776687666d2a6698f3bd872a3e1e6fa24b/scripts/inekf_odom.py#L159
  
Even more minor change, I corrected a typo in the readme ;)