### PR TITLE
Fix: use correct name for go2_description and declare build dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(inekf REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(go2_description REQUIRED)
+find_package(unitree_description REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 unset(PYTHON_SOABI)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The main dependencies of this package are:
 * [ROS2](https://docs.ros.org/en/jazzy/Installation.html)
 * Unitree ros2 interface: https://github.com/unitreerobotics/unitree_ros2
 * Our fork of the invariant ekf lib: https://github.com/inria-paris-robotics-lab/invariant-ekf
-* Our fork of the go2 urdf files : https://github.com/inria-paris-robotics-lab/go2_description
+* Our fork of the unitree urdf files : https://github.com/inria-paris-robotics-lab/unitree_description
 * Pinocchio (conda or apt installable, but might already come with your ros install)
 
 

--- a/launch/go2_state_publisher.launch.py
+++ b/launch/go2_state_publisher.launch.py
@@ -1,10 +1,10 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from go2_description import GO2_DESCRIPTION_URDF_PATH
+from unitree_description import GO2_DESCRIPTION_URDF_PATH
 
 
 def generate_launch_description():
-    # Read go2 urdf from go2_description
+    # Read go2 urdf from unitree_description
     with open(GO2_DESCRIPTION_URDF_PATH, "r") as info:
         robot_desc = info.read()
 

--- a/package.xml
+++ b/package.xml
@@ -18,9 +18,9 @@
   <depend>builtin_interfaces</depend>
   <depend>inekf</depend>
   <depend>tf2</depend>
+  <depend>unitree_description</depend>
 
   <exec_depend>pinocchio</exec_depend>
-  <exec_depend>go2_description</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/scripts/dumb_odom.py
+++ b/scripts/dumb_odom.py
@@ -8,7 +8,7 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from nav_msgs.msg import Odometry
 import pinocchio as pin
-from go2_description.loader import loadGo2
+from unitree_description.loader import loadGo2
 
 from unitree_go.msg import LowState
 from tf2_ros import TransformBroadcaster

--- a/scripts/inekf_odom.py
+++ b/scripts/inekf_odom.py
@@ -14,7 +14,7 @@ from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import TransformStamped
 from rcl_interfaces.msg import ParameterDescriptor as PD
 from inekf import RobotState, NoiseParams, InEKF, Kinematics
-from go2_description.loader import loadGo2
+from unitree_description.loader import loadGo2
 
 
 # ==============================================================================


### PR DESCRIPTION
When I tried building a ros ws with both `go2_odometry´ and `go2_description` (which was apparently renamed to `unitree_description`?), `go2_odometry` fails because `go2_description` is listed as `exec_depend` and not `depend` in its `package.xml`, so I changed this to match the new name and the build requirement.

Is it intentional that it was listed as an `exec_depend `despite being listed in `CMakeLists.txt`?